### PR TITLE
Fix typos and minor error in tests

### DIFF
--- a/test/credentials.test.ts
+++ b/test/credentials.test.ts
@@ -3,64 +3,64 @@ import { credentials } from '../src/credentials';
 
 describe('qvi credentials', () => {
     it('should create legal entity credential', () => {
-        let auth = new credentials.LegalEntityCredentialData({
+        let le = new credentials.LegalEntityCredentialData({
             timestamp: 'timestamp',
             issuee: 'recipient',
             LEI: 'an LEI',
         });
 
-        expect(auth.d).toBe('EOJuU6TMOARm-VyjRoApxT-K8GD65eZRn-sPKZQInUKe');
-        expect(auth.i).toBe('recipient');
-        expect(auth.dt).toBe('timestamp');
-        expect(auth.LEI).toBe('an LEI');
+        expect(le.d).toBe('EOJuU6TMOARm-VyjRoApxT-K8GD65eZRn-sPKZQInUKe');
+        expect(le.i).toBe('recipient');
+        expect(le.dt).toBe('timestamp');
+        expect(le.LEI).toBe('an LEI');
     });
 
     it('should create ecr credential', () => {
-        let auth =
-            new credentials.EngagementContextRoleAuthorizationCredentialData({
-                qviAID: 'qvi_aid',
-                timestamp: 'timestamp',
+        let ecr =
+            new credentials.EngagementContextRoleCredentialData({
+                nonce: 'a nonce',
                 issuee: 'recipient',
+                timestamp: 'timestamp',
                 LEI: 'an LEI',
                 personLegalName: 'My Legal Name',
                 engagementContextRole: 'my context role',
             });
 
-        expect(auth.d).toBe('EB9QkDZJW5iS2vyiTJQ1lVAo1qImK_HteOXaZE9aQRjG');
-        expect(auth.i).toBe('qvi_aid');
-        expect(auth.dt).toBe('timestamp');
-        expect(auth.AID).toBe('recipient');
-        expect(auth.LEI).toBe('an LEI');
-        expect(auth.personLegalName).toBe('My Legal Name');
-        expect(auth.engagementContextRole).toBe('my context role');
+        expect(ecr.d).toBe('EA_-RuJ0fFvWzHBWqVs5FqDJL3DUkexDRM4qKetTL1rL');
+        expect(ecr.u).toBe('a nonce');
+        expect(ecr.i).toBe('recipient');
+        expect(ecr.dt).toBe('timestamp');
+        expect(ecr.LEI).toBe('an LEI');
+        expect(ecr.personLegalName).toBe('My Legal Name');
+        expect(ecr.engagementContextRole).toBe('my context role');
     });
 
     it('should create oor credential', () => {
-        let auth =
-            new credentials.OfficialOrganizationalRoleAuthorizationCredentialData(
+        let oor =
+            new credentials.OfficialOrganizationalRoleCredentialData(
                 {
-                    qviAID: 'qvi_aid',
-                    timestamp: 'timestamp',
+                    nonce: 'a nonce',
                     issuee: 'recipient',
+                    timestamp: 'timestamp',
                     LEI: 'an LEI',
                     personLegalName: 'My Legal Name',
                     officialOrganizationalRole: 'my official role',
                 }
             );
 
-        expect(auth.d).toBe('EKfY9zJk7F3KqOESHCLOf0HKofNfeigKveDMy-3QQGNt');
-        expect(auth.i).toBe('qvi_aid');
-        expect(auth.dt).toBe('timestamp');
-        expect(auth.AID).toBe('recipient');
-        expect(auth.LEI).toBe('an LEI');
-        expect(auth.personLegalName).toBe('My Legal Name');
-        expect(auth.officialOrganizationalRole).toBe('my official role');
+        expect(oor.d).toBe('ECQty9qAGnqCzxHkfucDmoaDPi_p6mAyoGqXHj1dhtqN');
+        expect(oor.u).toBe('a nonce');
+        expect(oor.i).toBe('recipient');
+        expect(oor.dt).toBe('timestamp');
+        expect(oor.LEI).toBe('an LEI');
+        expect(oor.personLegalName).toBe('My Legal Name');
+        expect(oor.officialOrganizationalRole).toBe('my official role');
     });
 });
 
 describe('le credentials', () => {
     it('should create ecr auth credential', () => {
-        let auth =
+        let ecrAuth =
             new credentials.EngagementContextRoleAuthorizationCredentialData({
                 qviAID: 'qvi_aid',
                 timestamp: 'timestamp',
@@ -70,16 +70,16 @@ describe('le credentials', () => {
                 engagementContextRole: 'my context role',
             });
 
-        expect(auth.d).toBe('EB9QkDZJW5iS2vyiTJQ1lVAo1qImK_HteOXaZE9aQRjG');
-        expect(auth.i).toBe('qvi_aid');
-        expect(auth.dt).toBe('timestamp');
-        expect(auth.LEI).toBe('an LEI');
-        expect(auth.personLegalName).toBe('My Legal Name');
-        expect(auth.engagementContextRole).toBe('my context role');
+        expect(ecrAuth.d).toBe('EB9QkDZJW5iS2vyiTJQ1lVAo1qImK_HteOXaZE9aQRjG');
+        expect(ecrAuth.i).toBe('qvi_aid');
+        expect(ecrAuth.dt).toBe('timestamp');
+        expect(ecrAuth.LEI).toBe('an LEI');
+        expect(ecrAuth.personLegalName).toBe('My Legal Name');
+        expect(ecrAuth.engagementContextRole).toBe('my context role');
     });
 
     it('should create oor auth credential', () => {
-        let auth =
+        let oorAuth =
             new credentials.OfficialOrganizationalRoleAuthorizationCredentialData(
                 {
                     qviAID: 'qvi_aid',
@@ -91,11 +91,11 @@ describe('le credentials', () => {
                 }
             );
 
-        expect(auth.d).toBe('EKfY9zJk7F3KqOESHCLOf0HKofNfeigKveDMy-3QQGNt');
-        expect(auth.i).toBe('qvi_aid');
-        expect(auth.dt).toBe('timestamp');
-        expect(auth.LEI).toBe('an LEI');
-        expect(auth.personLegalName).toBe('My Legal Name');
-        expect(auth.officialOrganizationalRole).toBe('my official role');
+        expect(oorAuth.d).toBe('EKfY9zJk7F3KqOESHCLOf0HKofNfeigKveDMy-3QQGNt');
+        expect(oorAuth.i).toBe('qvi_aid');
+        expect(oorAuth.dt).toBe('timestamp');
+        expect(oorAuth.LEI).toBe('an LEI');
+        expect(oorAuth.personLegalName).toBe('My Legal Name');
+        expect(oorAuth.officialOrganizationalRole).toBe('my official role');
     });
 });

--- a/test/edges.test.ts
+++ b/test/edges.test.ts
@@ -64,7 +64,7 @@ describe('edges', () => {
         let data =
             new edges.OfficialOrganizationalRoleAuthorizationCredentialEdgeData(
                 {
-                    legalEntityCredentialSAID: 'my ecr auth credential said',
+                    legalEntityCredentialSAID: 'my oor auth credential said',
                 }
             );
 
@@ -72,8 +72,8 @@ describe('edges', () => {
             le: data,
         });
 
-        expect(edge.d).toBe('EFmitYRo5Dgijnr0rtQ0QW0A-MGPxozV3e4F6BUSVWSR');
-        expect(edge.le.n).toBe('my ecr auth credential said');
+        expect(edge.d).toBe('EMC_mzR4FVVwme-ZQg9hpEuSVIRc7sbp4skM4TYfbj2v');
+        expect(edge.le.n).toBe('my oor auth credential said');
         expect(edge.le.s).toBe(schema.LE);
     });
 });

--- a/test/le.test.ts
+++ b/test/le.test.ts
@@ -15,7 +15,7 @@ describe('a legal entity', () => {
         let le = new LE(client, 'qvi_name', 'qvi_registry_aid');
         let data =
             new credentials.EngagementContextRoleAuthorizationCredentialData({
-                qviAID: 'issueing to this qvi',
+                qviAID: 'issuing to this qvi',
                 timestamp: 'time stamp',
                 issuee: 'ecr is meant for this aid',
                 LEI: 'LEI',
@@ -73,7 +73,7 @@ describe('a legal entity', () => {
         let data =
             new credentials.OfficialOrganizationalRoleAuthorizationCredentialData(
                 {
-                    qviAID: 'issueing to this qvi',
+                    qviAID: 'issuing to this qvi',
                     timestamp: 'time stamp',
                     issuee: 'oor is meant for this aid',
                     LEI: 'LEI',


### PR DESCRIPTION
- `le.test.ts`: fix typos.
- `edges.test.ts`: fix typos in the test for OOR AUTH credential SAID. The digest `d` is also fixed accordingly.
- `credentials.test.ts`: The test had a wrong scripts for credentials issued by a QVI. A QVI should issue a OOR and ECR credentials, not OOR AUTH and ECR AUTH. I have also changed the variables' names to make them more readable.
 