### PR TITLE
Change privacy for ECR credential to true

### DIFF
--- a/src/qvi.ts
+++ b/src/qvi.ts
@@ -82,7 +82,7 @@ export class QVI {
                 data,
                 rules.ECR,
                 edge,
-                false
+                true
             );
     }
 

--- a/test/qvi.test.ts
+++ b/test/qvi.test.ts
@@ -92,7 +92,7 @@ describe('a qvi', () => {
                 anyOfClass(credentials.EngagementContextRoleCredentialData),
                 rules.ECR,
                 anyOfClass(edges.EngagementContextRoleCredentialEdge),
-                false
+                true
             )
         ).once();
 


### PR DESCRIPTION
The top-level `u` is a required field in the ECR vLEI schema.