### PR TITLE
Direct issuance of ECR vLEI credential by a legal entity

### DIFF
--- a/src/edges.ts
+++ b/src/edges.ts
@@ -121,6 +121,66 @@ namespace edges {
     }
 
     /**
+     * DirectEngagementContextRoleEdgeArgs
+     *
+     * Parameters for {@link DirectEngagementContextRoleCredentialEdge}
+     *
+     * @property {le DirectEngagementContextRoleCredentialEdgeData} data for the edge
+     */
+    export interface DirectEngagementContextRoleCredentialEdgeArgs {
+        le: DirectEngagementContextRoleCredentialEdgeData;
+    }
+
+    /**
+     * DirectEngagementContextRoleEdge
+     *
+     * Used as edge property for {@link createDirectEngagementContextRoleCredential}
+     *
+     * @property {d string} digest of {@link DirectEngagementContextRoleCredentialEdge} block
+     * @property {le DirectEngagementContextRoleCredentialEdgeData} nested block of {@link DirectEngagementContextRoleEdgeData}
+     */
+    export class DirectEngagementContextRoleCredentialEdge {
+        readonly d: string;
+        readonly le: DirectEngagementContextRoleCredentialEdgeData;
+
+        constructor({ le }: DirectEngagementContextRoleCredentialEdgeArgs) {
+            this.d = Saider.saidify({ d: '', le: le })[1]['d'];
+            this.le = le;
+        }
+    }
+
+    /**
+     * DirectEngagementContextRoleCredentialEdgeDataArgs
+     *
+     * Parameters for {@link DirectEngagementContextRoleCredentialEdgeData}
+     *
+     * @property {legalEntityCredentialSAID string} SAID of previously issued Legal Entity credential
+     */
+    export interface DirectEngagementContextRoleCredentialEdgeDataArgs {
+        legalEntityCredentialSAID: string;
+    }
+
+    /**
+     * DirectEngagementContextRoleCredentialEdgeData
+     *
+     * Nested property for {@link DirectEngagementContextRoleCredentialEdge}
+     *
+     * @property {n string} SAID of previously issued Legal Entity credential
+     * @property {s string} SAID of Legal Entity credential schema
+     */
+    export class DirectEngagementContextRoleCredentialEdgeData {
+        n: string;
+        s: string;
+
+        constructor({
+            legalEntityCredentialSAID,
+        }: DirectEngagementContextRoleCredentialEdgeDataArgs) {
+            this.n = legalEntityCredentialSAID;
+            this.s = schema.LE;
+        }
+    }
+
+    /**
      * EngagementContextRoleAuthorizationEdgeArgs
      *
      * Parameters for {@link EngagementContextRoleAuthorizationEdge}

--- a/src/le.ts
+++ b/src/le.ts
@@ -107,7 +107,7 @@ export class LE {
                 data,
                 rules.ECR,
                 edge,
-                false
+                true
             );
     }
 }

--- a/src/le.ts
+++ b/src/le.ts
@@ -83,4 +83,31 @@ export class LE {
                 false
             );
     }
+
+    /**
+     * Create Engagement Context Role Credential directly from LE
+     *
+     * @param {AID} issuee
+     * @param {credentials.EngagementContextRoleCredentialData} data
+     * @param {edges.DirectEngagementContextRoleCredentialEdge} edge
+     * @returns {Promise<any>} A promise to the long-running operation
+     */
+    public async createDirectEngagementContextRoleCredential(
+        issuee: AID,
+        data: credentials.EngagementContextRoleCredentialData,
+        edge: edges.DirectEngagementContextRoleCredentialEdge
+    ): Promise<any> {
+        return await this.client
+            .credentials()
+            .issue(
+                this.name,
+                this.registryAID,
+                schema.ECR,
+                issuee,
+                data,
+                rules.ECR,
+                edge,
+                false
+            );
+    }
 }

--- a/test/edges.test.ts
+++ b/test/edges.test.ts
@@ -30,6 +30,21 @@ describe('edges', () => {
         expect(edge.auth.s).toBe(schema.ECRAuth);
     });
 
+    it('should create direct engagement context role credential edge', () => {
+        let data = new edges.DirectEngagementContextRoleCredentialEdgeData({
+            legalEntityCredentialSAID:
+                'my ecr auth credential said',
+        });
+
+        let edge = new edges.DirectEngagementContextRoleCredentialEdge({
+            le: data,
+        });
+
+        expect(edge.d).toBe('EFmitYRo5Dgijnr0rtQ0QW0A-MGPxozV3e4F6BUSVWSR');
+        expect(edge.le.n).toBe('my ecr auth credential said');
+        expect(edge.le.s).toBe(schema.LE);
+    });
+
     it('should create official organizational role credential edge', () => {
         let data = new edges.OfficialOrganizationalRoleCredentialEdgeData({
             officialOrganizationalRoleAuthorizationCredentialSAID:

--- a/test/le.test.ts
+++ b/test/le.test.ts
@@ -160,7 +160,7 @@ describe('a legal entity', () => {
                 anyOfClass(credentials.EngagementContextRoleCredentialData),
                 rules.ECR,
                 anyOfClass(edges.DirectEngagementContextRoleCredentialEdge),
-                false
+                true
             )
         ).once();
 

--- a/test/le.test.ts
+++ b/test/le.test.ts
@@ -122,4 +122,58 @@ describe('a legal entity', () => {
             'ENPXp1vQzRF6JwIuS-mp2U8Uf1MoADoP_GqQ62VsDZWY'
         );
     });
+
+    it('should create direct engagement context role credential', () => {
+        let mockedClient: SignifyClient = mock(SignifyClient);
+
+        let c: Credentials = mock(Credentials);
+        when(mockedClient.credentials()).thenReturn(instance(c));
+
+        let client = instance(mockedClient);
+        let le = new LE(client, 'le_name', 'le_registry_aid');
+        let data = new credentials.EngagementContextRoleCredentialData({
+            issuee: 'issuee',
+            nonce: 'nonce',
+            timestamp: 'timestamp',
+            LEI: 'an LEI',
+            personLegalName: 'person legal name',
+            engagementContextRole: 'my context role',
+        });
+        let edgeData =
+            new edges.DirectEngagementContextRoleCredentialEdgeData({
+                legalEntityCredentialSAID: 'a SAID',
+            });
+        let edge = new edges.DirectEngagementContextRoleCredentialEdge({
+            le: edgeData,
+        });
+
+        le.createDirectEngagementContextRoleCredential('issuee aid', data, edge);
+
+        let cap = capture(c.issue).last();
+
+        verify(
+            c.issue(
+                'le_name',
+                'le_registry_aid',
+                'EEy9PkikFcANV1l7EHukCeXqrzT1hNZjGlUk7wuMO5jw',
+                'issuee aid',
+                anyOfClass(credentials.EngagementContextRoleCredentialData),
+                rules.ECR,
+                anyOfClass(edges.DirectEngagementContextRoleCredentialEdge),
+                false
+            )
+        ).once();
+
+        let DATA_ARG = 4;
+        expect(cap[DATA_ARG].LEI).toBe('an LEI');
+
+        let EDGE_ARG = 6;
+        expect(cap[EDGE_ARG].d).toBe(
+            'ECz2B-zXe2GADR_sZ9WEjaf1WXPKcOBBdW6Qeb6TIkoA'
+        );
+        expect(cap[EDGE_ARG].le.n).toBe('a SAID');
+        expect(cap[EDGE_ARG].le.s).toBe(
+            'ENPXp1vQzRF6JwIuS-mp2U8Uf1MoADoP_GqQ62VsDZWY'
+        );
+    });
 });


### PR DESCRIPTION
I have made an attempt to fix issue #17. 

I added a new function `createDirectEngagementContextRoleCredential` to `le.ts` and the following classes and interfaces in `edges.ts`
```
interface DirectEngagementContextRoleCredentialEdgeArgs
class DirectEngagementContextRoleCredentialEdge
interface DirectEngagementContextRoleCredentialEdgeDataArg
class DirectEngagementContextRoleCredentialEdgeData
```

I have also added more tests accordingly. I am not sure if the naming for these edge classes and interfaces are appropriate.